### PR TITLE
Add `mix tailwind.install` to setup command

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule HexDocsSearch.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
+      setup: ["deps.get", "ecto.setup", "tailwind.install", "assets.setup", "assets.build"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],


### PR DESCRIPTION
If you do not have a binary of tailwind available, the command will get it properly linked up and downloaded for you for the appropriate architecture.

I ran into this while forking this project to work on some campaign financing analysis tooling for NYS and figured I'd just upstream it since many others may not have this binary available if learning from newer posts like this.